### PR TITLE
Add deployment configuration for Docker Hub registry, closes #18.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,11 @@ test:
     - docker run -d --name=grunt -p 49160:80 flexion/flexion-ads-18f-response; sleep 60
     - docker logs -t grunt
     - curl --retry 10 --retry-delay 5 -v http://localhost:49160
+
+deployment:
+  hub:
+    branch: develop
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker push bdruth/flexion-ads-18f-response
+      # Will change to flexion public repo when released.


### PR DESCRIPTION
Private API data is set in CircleCI ENV vars.
