### PR TITLE
Add CIRCLE_BUILD_NUM tag to docker push. Closes #83

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,5 +18,5 @@ deployment:
     branch: develop
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push bdruth/flexion-ads-18f-response
+      - docker push bdruth/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM
       # Will change to flexion public repo when released.


### PR DESCRIPTION
Pushing the new image to the registry tagged with the CI build # will allow ECS to update the service with the correct build.
