### PR TITLE
Switch container build/push to registry to use flexion org. Closes #95.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,11 +5,11 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker build -t bdruth/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM .
+    - docker build -t flexion/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM .
 
 test:
   override:
-    - docker run -d --name=grunt -p 49160:80 bdruth/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM; sleep 60
+    - docker run -d --name=grunt -p 49160:80 flexion/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM; sleep 60
     - docker logs -t grunt
     - curl --retry 10 --retry-delay 5 -v http://localhost:49160
 
@@ -18,5 +18,5 @@ deployment:
     branch: develop
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker push bdruth/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM
+      - docker push flexion/flexion-ads-18f-response:v_$CIRCLE_BUILD_NUM
       # Will change to flexion public repo when released.


### PR DESCRIPTION
ECS task definition template will need to be updated with new repo location.
