### PR TITLE
Update to a new API key, old one may have expired.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ USER root
 RUN apt-get update && apt-get install -y \
   git-core \
   bzip2 \
+  libssl-dev \
   ruby
 
 RUN gem install sass
-  
+
 RUN chown -R node .
 
 USER node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM shinymayhem/node
-COPY . /var/www
 
 USER root
 RUN apt-get update && apt-get install -y \
@@ -10,10 +9,14 @@ RUN apt-get update && apt-get install -y \
 
 RUN gem install sass
 
+COPY .bowerrc bower.json package.json /var/www/
 RUN chown -R node .
 
 USER node
 
 RUN npm install; bower install
+
+COPY . /var/www
+
 ENV PORT 80
 CMD ["authbind", "--deep", "grunt", "serve:dist"]

--- a/bower.json
+++ b/bower.json
@@ -16,8 +16,8 @@
     "lodash": "~2.4.1",
     "angular-ui-router": "~0.2.10",
     "d3": "3.5.5",
-    "nvd3": "~1.8.1",
-    "angularjs-nvd3-directives": "~0.0.7",
+    "nvd3": "1.8.1",
+    "angularjs-nvd3-directives": "0.0.7",
     "angular-typeahead": "~0.2.3",
     "angular-spinner": "~0.6.1",
     "angular-aria": "1.4.1"
@@ -29,6 +29,6 @@
   "resolutions": {
     "angular": "1.4.1",
     "d3": "3.5.5",
-    "nvd3": "~1.8.1"
+    "nvd3": "1.8.1"
   }
 }

--- a/client/app/main/main.controller.coffee
+++ b/client/app/main/main.controller.coffee
@@ -54,7 +54,7 @@ angular.module('gsfFdaApp').controller 'MainCtrl', ($scope, $http, usSpinnerServ
           },
           {
             field: 'receivedate'
-            terms: [ { term: '[20140101+TO+20150101]' } ]
+            terms: [ { term: '[20150101+TO+20160101]' } ]
             isAnd: true
           }
         ]
@@ -108,7 +108,7 @@ angular.module('gsfFdaApp').controller 'MainCtrl', ($scope, $http, usSpinnerServ
         {
           field: "receivedate",
           terms: [
-            {term: "[20140101+TO+20150101]"}
+            {term: "[20150101+TO+20160101]"}
           ],
           isAnd: true
         }

--- a/server/components/services/openFDA.js
+++ b/server/components/services/openFDA.js
@@ -41,7 +41,7 @@ exports.getPath = function(query)
   //see https://open.fda.gov/api/reference/#query-syntax
  var field, j, len1, queryString, ref, ref1, term;
   //TODO production app will read this from environment variable
-  queryString = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=';
+  queryString = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=';
   ref = query.search.fields;
   for (var i = 0, len = ref.length; i < len; i++) {
     field = ref[i];

--- a/server/components/services/openFDA.spec.js
+++ b/server/components/services/openFDA.spec.js
@@ -36,7 +36,7 @@ describe('openFDA.getPath', function() {
   //https://api.fda.gov/drug/event.json?search=brand_name:lyrica+AND+receivedate:[20140101+TO+20150101]&count=receivedate
 
   it('should respond with a properly formatted query string', function(done) {
-    var expectedResult = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=patient.drug.medicinalproduct:nonsteroidal+anti-inflammatory+drug';
+    var expectedResult = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=patient.drug.medicinalproduct:nonsteroidal+anti-inflammatory+drug';
     var result = openFDA.getPath(search);
     result.should.be.instanceof(String);
     result.should.equal(expectedResult);
@@ -44,7 +44,7 @@ describe('openFDA.getPath', function() {
   });
 
   it('should recognize an exact term and put quotes around it', function(done) {
-    var expectedResult = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=patient.drug.openfda.pharm_class_epc:"nonsteroidal+anti-inflammatory+drug"&count=patient.reaction.reactionmeddrapt.exact';
+    var expectedResult = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=patient.drug.openfda.pharm_class_epc:"nonsteroidal+anti-inflammatory+drug"&count=patient.reaction.reactionmeddrapt.exact';
     var result = openFDA.getPath(request2);
     result.should.be.instanceof(String);
     result.should.equal(expectedResult);
@@ -52,7 +52,7 @@ describe('openFDA.getPath', function() {
   });
 
   it('should be able to add an exact count', function(done) {
-    var expectedResult = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=patient.drug.openfda.pharm_class_epc:"nonsteroidal+anti-inflammatory+drug"&count=patient.reaction.reactionmeddrapt.exact';
+    var expectedResult = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=patient.drug.openfda.pharm_class_epc:"nonsteroidal+anti-inflammatory+drug"&count=patient.reaction.reactionmeddrapt.exact';
     var result = openFDA.getPath(request2);
     result.should.be.instanceof(String);
     result.should.equal(expectedResult);
@@ -82,7 +82,7 @@ describe('openFDA.getPath', function() {
       }
     };
 
-    var expectedResult = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=brand_name:lyrica+AND+receivedate:[20140101+TO+20150101]&count=receivedate';
+    var expectedResult = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=brand_name:lyrica+AND+receivedate:[20140101+TO+20150101]&count=receivedate';
     var result = openFDA.getPath(request3);
     result.should.be.instanceof(String);
     result.should.equal(expectedResult);
@@ -117,7 +117,7 @@ describe('openFDA.getPath', function() {
         count: {field:"receivedate"}
       }
     };
-    var expectedResult = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=brand_name:lyrica+AND+serious:1+AND+receivedate:[20140101+TO+20150101]&count=receivedate';
+    var expectedResult = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=brand_name:lyrica+AND+serious:1+AND+receivedate:[20140101+TO+20150101]&count=receivedate';
     var result = openFDA.getPath(request4);
     result.should.be.instanceof(String);
     result.should.equal(expectedResult);
@@ -148,7 +148,7 @@ describe('openFDA.getPath', function() {
         count: {field:"patient.drug.medicinalproduct"}
       }
     };
-    var expectedResult = '/drug/event.json?api_key=1tng2lKHWL3Upt0LfvdyEsl82L5ROFYBgbfUAJHL&search=patient.drug.openfda.pharm_class_epc:anti-epileptic+agent+AND+receivedate:[20140101+TO+20150101]&count=patient.drug.medicinalproduct';
+    var expectedResult = '/drug/event.json?api_key=SnZ9SiOZ3U2z0DUjkF6BapavTTLeagFdOlra02AB&search=patient.drug.openfda.pharm_class_epc:anti-epileptic+agent+AND+receivedate:[20140101+TO+20150101]&count=patient.drug.medicinalproduct';
     var result = openFDA.getPath(request5);
     result.should.be.instanceof(String);
     result.should.equal(expectedResult);


### PR DESCRIPTION
Fix miscellaneous other issues:
* nvd3 error between minor patch versions shifting
* fix: docker annoyingly rebuilds basically everything when src changes, because the COPY is the first things after FROM
* grab 2015 FDA data in query, not 2014 data